### PR TITLE
Add documentation comments for entire public API

### DIFF
--- a/config.go
+++ b/config.go
@@ -103,6 +103,7 @@ func (c PollingConfig) Validate() error {
 	return nil
 }
 
+// LoadConfig reads and parses the configuration file at the given path
 func LoadConfig(configPath string) (*DaemonConfig, error) {
 	if configPath == "" {
 		return nil, fmt.Errorf("no file specified")

--- a/daemon.go
+++ b/daemon.go
@@ -13,7 +13,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Daemon manages Route53 resources
 type Daemon struct {
+	// Config controls the dynamic53 daemon's behavior
 	Config DaemonConfig
 
 	utility ZoneUtility
@@ -26,6 +28,7 @@ func NewDaemon(config DaemonConfig, route53Client *route53.Client) *Daemon {
 	}
 }
 
+// Start begins the dynamic53 daemon's poll-and-update loop
 func (d *Daemon) Start(ctx context.Context) {
 	logger := zerolog.Ctx(ctx)
 	logger.Info().Stringer("pollingInterval", d.Config.Polling.Interval).Msg("Starting dynamic53 daemon")

--- a/daemon.go
+++ b/daemon.go
@@ -16,13 +16,13 @@ import (
 type Daemon struct {
 	Config DaemonConfig
 
-	route53Api Route53Api
+	utility ZoneUtility
 }
 
 func NewDaemon(config DaemonConfig, route53Client *route53.Client) *Daemon {
 	return &Daemon{
-		Config:     config,
-		route53Api: Route53Api{Manager: route53Client},
+		Config:  config,
+		utility: ZoneUtility{Manager: route53Client},
 	}
 }
 
@@ -106,7 +106,7 @@ func (d *Daemon) updateRecords(ctx context.Context, zone ZoneConfig, ipv4 net.IP
 
 	logger.Debug().Msg("Beginning update pass for hosted zone")
 
-	hostedZone, err := d.route53Api.HostedZoneFromConfig(logCtx, zone)
+	hostedZone, err := d.utility.HostedZoneFromConfig(logCtx, zone)
 	if err != nil {
 		logger.Error().Err(err).Send()
 		return
@@ -125,7 +125,7 @@ func (d *Daemon) updateRecords(ctx context.Context, zone ZoneConfig, ipv4 net.IP
 	logger.Debug().Msg("Retrieved info about hosted zone")
 
 	ttl := int64(d.Config.Polling.Interval.Seconds())
-	batch, err := d.route53Api.GetChangesForZone(logCtx, hostedZone, zone.Records, ttl, ipv4)
+	batch, err := d.utility.GetChangesForZone(logCtx, hostedZone, zone.Records, ttl, ipv4)
 	if err != nil {
 		logger.Error().Err(err).Send()
 		return
@@ -143,5 +143,5 @@ func (d *Daemon) updateRecords(ctx context.Context, zone ZoneConfig, ipv4 net.IP
 		return
 	}
 
-	d.route53Api.ApplyChangeBatch(logCtx, hostedZone, batch)
+	d.utility.ApplyChangeBatch(logCtx, hostedZone, batch)
 }

--- a/util.go
+++ b/util.go
@@ -63,6 +63,9 @@ func listSeparator(length int, index int, separator string) string {
 	return separator
 }
 
+// GenerateIAMPolicy returns a JSON string representing an identity-based AWS
+// IAM policy granting the necessary permissions for a dynamic53 client to
+// manage the zones and records specified in the given configuration
 func GenerateIAMPolicy(cfg DaemonConfig) (string, error) {
 	funcs := template.FuncMap{"listSeparator": listSeparator}
 	tmpl, err := template.New("iam-policy").Funcs(funcs).Parse(IAM_POLICY_TEMPLATE)


### PR DESCRIPTION
Fixes #2 

Also renames the wrapper types around the Route 53 API to make their names more descriptive of actual function